### PR TITLE
Use correct JSONAPI formatter instead of blindly using dasherize

### DIFF
--- a/lib/jsonapi/resources/matchers/have_attribute.rb
+++ b/lib/jsonapi/resources/matchers/have_attribute.rb
@@ -16,7 +16,7 @@ module JSONAPI
 
           serialized_hash = JSONAPI::ResourceSerializer.new(resource_class).
             serialize_to_hash(resource).with_indifferent_access
-          expected_key = name.to_s.dasherize
+          expected_key = JSONAPI.configuration.key_formatter.format(name.to_s)
           attributes = serialized_hash["data"]["attributes"]
           return false if attributes.nil?
           attributes.has_key?(expected_key)

--- a/lib/jsonapi/resources/matchers/relationship.rb
+++ b/lib/jsonapi/resources/matchers/relationship.rb
@@ -33,7 +33,7 @@ module JSONAPI
         def has_key_in_relationships?
           serialized_hash = JSONAPI::ResourceSerializer.new(resource.class).
             serialize_to_hash(resource).with_indifferent_access
-          expected_key = name.to_s.dasherize
+          expected_key = JSONAPI.configuration.key_formatter.format(name.to_s)
           relationships = serialized_hash["data"]["relationships"]
           return false if relationships.nil?
           relationships.has_key?(expected_key)


### PR DESCRIPTION
`jsonapi-resources` offers more than a single way of formatting keys. This fix allow `jsonapi-resources-matchers` to use the formatter from `jsonapi-resources` instead of using `dasherize` everytimes.