### PR TITLE
Developer must call `require 'jsonapi/resources/matchers'`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- Developer must `require "jsonapi/resources/matchers"`
+
 ## [1.0.0] - 2016-02-28
 ### Changed
 - Require jsonapi-resources 0.9.0 and above

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Currently, only RSpec matchers exist.
 Add this line to your application's Gemfile (in a `test` group):
 
 ```ruby
-gem 'jsonapi-resources-matchers', require: false
+gem 'jsonapi-resources-matchers'
 ```
 
 And then execute:
@@ -23,7 +23,7 @@ Or install it yourself as:
 Require the gem in your `spec/spec_helper`:
 
 ```ruby
-require 'jsonapi-resources-matchers'
+require 'jsonapi/resources/matchers'
 ```
 
 ## Usage

--- a/lib/jsonapi-resources-matchers.rb
+++ b/lib/jsonapi-resources-matchers.rb
@@ -1,1 +1,0 @@
-require 'jsonapi/resources/matchers'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,4 +2,4 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require File.expand_path("../dummy/config/environment", __FILE__)
 require 'pry'
 require 'jsonapi-resources'
-require 'jsonapi-resources-matchers'
+require 'jsonapi/resources/matchers'


### PR DESCRIPTION
When installing directly in a Rails application, adding `require: false`
in the Gemfile was sufficient. However, when using
jsonapi-resources-matchers in a Rails engine, it would load the gem
in the Rails app and cause issues.

To simplify things, and not need `require: false` in the Gemfile,
use must require the matchers file instead.