### PR TITLE
Fix Bundler::GemRequireError in test environment

### DIFF
--- a/lib/jsonapi/resources/matchers/integrations/rspec.rb
+++ b/lib/jsonapi/resources/matchers/integrations/rspec.rb
@@ -1,4 +1,5 @@
 if defined?(RSpec)
+  require 'rspec/core'
   RSpec.configure do |c|
     c.include JSONAPI::Resources::Matchers, type: :resource
   end


### PR DESCRIPTION
Running `RAILS_ENV=test rake db:migrate` in a Rails 5.1 project using `jsonapi-resources-matchers` in its `:test` gems group leads to the following error:

```
rake aborted!
Bundler::GemRequireError: There was an error while trying to load the gem 'jsonapi-resources-matchers'.
Gem Load Error is: undefined method `configure' for RSpec:Module
Backtrace for gem load error is:
/home/cesar/.rvm/gems/ruby-2.3.3/gems/jsonapi-resources-matchers-1.0.0/lib/jsonapi/resources/matchers/integrations/rspec.rb:2:in `<top (required)>'
```

This was due to the fact that in a standard Rails 5.1 project, `rspec/core` is not required by default before `Bundler.require(*Rails.groups)` runs in `application.rb`.

Requiring `rspec/core` prior to the inclusion of the matchers fixes the issue.