### PR TITLE
Add negated failure message

### DIFF
--- a/lib/jsonapi/resources/matchers/have_attribute.rb
+++ b/lib/jsonapi/resources/matchers/have_attribute.rb
@@ -28,11 +28,15 @@ module JSONAPI
           resource_name = resource.class.name.demodulize
           %Q(expected #{resource_name} to have attribute #{name})
         end
+        
+        def failure_message_when_negated
+          resource_name = resource.class.name.demodulize
+          %Q(expected #{resource_name} to not have attribute #{name}, but it was present)
+        end
 
         def description
           "have attribute #{name}"
         end
-
       end
     end
   end


### PR DESCRIPTION
When using `expect(resource).to_not have_attribute` the failure message description is not found. This adds support for this.