### PR TITLE
Add Rails 5 compatible version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [TBA]
+### Added
+- Make gem Rails 5 compatible
+- Simplify relationship and attribute matchers
+
 ## [Unreleased]
 ### Changed
 - Developer must `require "jsonapi/resources/matchers"`

--- a/jsonapi-resources-matchers.gemspec
+++ b/jsonapi-resources-matchers.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jsonapi-resources", ">= 0.9.0"
+  spec.add_dependency "jsonapi-resources", ">= 0.9"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/jsonapi/resources/matchers/have_attribute.rb
+++ b/lib/jsonapi/resources/matchers/have_attribute.rb
@@ -11,17 +11,21 @@ module JSONAPI
 
         def matches?(resource)
           self.resource = resource
-
           CheckSerialization.(self.resource)
 
           resource_class = resource.class
 
-          serialized_hash = JSONAPI::ResourceSerializer.new(resource_class).
-            serialize_to_hash(resource).with_indifferent_access
-          expected_key = JSONAPI.configuration.key_formatter.format(name.to_s)
-          attributes = serialized_hash["data"]["attributes"]
-          return false if attributes.nil?
-          attributes.has_key?(expected_key)
+          attributes = resource.fetchable_fields
+          return false if attributes.blank?
+
+          formatter = JSONAPI.configuration.key_formatter
+
+          expected_key = formatter.format(name.to_s)
+          formatted_attributes = attributes.map do |attribute|
+            formatter.format(attribute.to_s)
+          end
+
+          formatted_attributes.include?(expected_key)
         end
 
         def failure_message

--- a/lib/jsonapi/resources/matchers/relationship.rb
+++ b/lib/jsonapi/resources/matchers/relationship.rb
@@ -36,12 +36,17 @@ module JSONAPI
         end
 
         def has_key_in_relationships?
-          serialized_hash = JSONAPI::ResourceSerializer.new(resource.class).
-            serialize_to_hash(resource).with_indifferent_access
-          expected_key = JSONAPI.configuration.key_formatter.format(name.to_s)
-          relationships = serialized_hash["data"]["relationships"]
-          return false if relationships.nil?
-          relationships.has_key?(expected_key)
+          relationships = resource.class._relationships
+          return false if relationships.blank?
+
+          formatter = JSONAPI.configuration.key_formatter
+
+          expected_key = formatter.format(name.to_s)
+          relationship_keys = relationships.keys.map do |key|
+            formatter.format(key.to_s)
+          end
+
+          relationship_keys.include?(expected_key)
         end
 
         def with_class_name(name)

--- a/lib/jsonapi/resources/matchers/version.rb
+++ b/lib/jsonapi/resources/matchers/version.rb
@@ -1,7 +1,7 @@
 module JSONAPI
   module Resources
     module Matchers
-      VERSION = "1.0.0"
+      VERSION = "1.1.0.alpha"
     end
   end
 end


### PR DESCRIPTION
### Changes Proposed in this Pull Request:
* Simplify relationship and attribute matchers
* `serialize_to_hash` is removed in `jsonapi-resources 0.10.0.pre`.